### PR TITLE
Provided riemax.euclidean

### DIFF
--- a/docs/manifold/euclidean.md
+++ b/docs/manifold/euclidean.md
@@ -1,0 +1,1 @@
+::: src.riemax.euclidean

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,3 +153,4 @@ nav:
       - manifold/index.md
       - geometry: manifold/geometry.md
       - operators: manifold/operators.md
+      - euclidean: manifold/euclidean.md

--- a/src/riemax/__init__.py
+++ b/src/riemax/__init__.py
@@ -1,2 +1,2 @@
 from . import manifold
-from .manifold import Manifold, geometry, operators
+from .manifold import Manifold, euclidean, geometry, operators

--- a/src/riemax/manifold/__init__.py
+++ b/src/riemax/manifold/__init__.py
@@ -1,2 +1,2 @@
-from . import geometry, operators, types
+from . import euclidean, geometry, operators, types
 from ._manifold import Manifold

--- a/src/riemax/manifold/euclidean.py
+++ b/src/riemax/manifold/euclidean.py
@@ -1,0 +1,47 @@
+import jax
+import jax.numpy as jnp
+
+
+def metric_tensor(x: jax.Array) -> jax.Array:
+
+    r"""Defines the metric tensor for Euclidean space.
+
+    In Euclidean space, the metric tensor is defined as the identity matrix
+
+    $$
+    g_{ij} = \delta_{ij}.
+    $$
+
+    !!! warning
+
+        The Euclidean metric defined in this manner is not differentiable. This could cause problems in some places.
+
+    Parameters:
+        x: position $p \in \mathbb{R}$ at which to evaluate the metric tensor
+
+    Returns:
+        metric tensor in Euclidean space -- the identity matrix
+    """
+
+    return jnp.eye(N=x.shape[-1])
+
+
+def distance(p: jax.Array, q: jax.Array) -> jax.Array:
+
+    r"""Compute Euclidean distance between points.
+
+    The Euclidean distance is simply defined by the L2 norm:
+
+    $$
+    d_E(p, q) = \lVert p - q \rVert_2.
+    $$
+
+    Parameters:
+        p: position $p \in \mathbb{R}$ of the first point
+        q: position $q \in \mathbb{R}$ of the second point
+
+    Returns:
+        euclidean distance between $p, q$
+    """
+
+    return jnp.sqrt(jnp.einsum('...i -> ...', (p - q) ** 2))


### PR DESCRIPTION
Provided `riemax.euclidean`, essentially basic functionality for defining
the metric tensor and distance function on Euclidean space.
