### PR TITLE
Provided exp/log maps

### DIFF
--- a/docs/manifold/geodesic.md
+++ b/docs/manifold/geodesic.md
@@ -1,0 +1,1 @@
+::: riemax.manifold.geodesic

--- a/docs/manifold/maps.md
+++ b/docs/manifold/maps.md
@@ -1,0 +1,32 @@
+# maps
+
+The `riemax.manifold.maps` module allows the user to define the exponential and log maps on a manifold. These are defined using the geodesic dynamics, defined in `riemax.manifold.geodesic`.
+
+## Types:
+
+```python
+type ExponentialMap = tp.Callable[[TangentSpace[jax.Array]], tuple[M[jax.Array], TangentSpace[jax.Array]]]
+type LogMap[*Ts] = tp.Callable[[M[jax.Array], M[jax.Array], *Ts], tuple[TangentSpace[jax.Array], bool]]
+```
+
+
+### Exponential Map
+
+Suppose we have a continuous, differentiable manifold, $M$. Given a point $p \in M$, and tangent vector $v \in T_p M$, there exists a unique geodesic $\gamma_v : [0, 1] \rightarrow M$ satisfying $\gamma_v(0) = p$, $\dot{\gamma}_v(0) = v$. The exponential map is defined by $\exp_p(v) = \gamma_v(1)$, or $\exp_p : T_p M \rightarrow M$.
+
+### Log Map
+
+Given two points $p, q \in M$, the $\log$ map provides the tangent-vector which, upon application of the exponential map, transports one point to the other.  The log map is the natural inverse of the exponential map, defined as $\log_p(q) = v$ such that $\exp_p(\log_p(q)) = q$. This mapping is not unique as there may be many tangent-vectors which connect the two points $p, q$.
+
+#### Shooting Solver
+
+Ordinarily, we would consider computing the $\log$ map a two-point boundary value problem. We can approach this using a shooting method, posing the problem: find $v \in T_p M$ such that $\exp_p (v) = q$. We define the residual
+
+$$
+r(v) = \exp_p(v) - q,
+$$
+
+and use a root-finding technique, such as Newton-Raphson, to obtain a solution. While this remains a principled approach, it is somewhat reliant on having a good initial guess for the solution.
+
+
+::: riemax.manifold.maps

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,6 +153,8 @@ nav:
       - manifold/index.md
       - geometry: manifold/geometry.md
       - operators: manifold/operators.md
+      - geodesic: manifold/geodesic.md
+      - maps: manifold/maps.md
       - euclidean: manifold/euclidean.md
     - numerical:
       - numerical/index.md

--- a/src/riemax/manifold/__init__.py
+++ b/src/riemax/manifold/__init__.py
@@ -1,2 +1,2 @@
-from . import euclidean, geometry, operators, types
+from . import euclidean, geodesic, geometry, maps, operators, types
 from ._manifold import Manifold

--- a/src/riemax/manifold/geodesic.py
+++ b/src/riemax/manifold/geodesic.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import typing as tp
+
+import einops
+import jax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+
+from ..numerical.integral_approximators import IntegralApproximationFn, mean_integration
+from ._marked import manifold_marker
+from .geometry import contravariant_metric_tensor, inner_product, sk_christoffel
+from .types import MetricFn, TangentSpace
+
+
+@manifold_marker.mark(jittable=True)
+def geodesic_dynamics(state: TangentSpace[jax.Array], metric: MetricFn) -> TangentSpace[jax.Array]:
+
+    r"""Compute update step for the geodesic dynamics.
+
+    The geodesic equation
+
+    $$
+    \ddot{\gamma}^k + \Gamma^k_{\phantom{k}ij} \dot{\gamma}^i \dot{\gamma}^j  = 0
+    $$
+
+    is a second order ordinary differential equation. We take the conventional approach of splitting
+    this into two first-order ordinary differential equations.
+
+    Parameters:
+        state: current state of the geodesic integration
+        metric: covariant metric tensor used
+
+    Returns:
+        derivatives used to compute update for the state
+    """
+
+    sk_christ = sk_christoffel(state.point, metric)
+    vector_dot = -jnp.einsum('kij, i, j -> k', sk_christ, state.vector, state.vector)
+
+    return TangentSpace[jax.Array](state.vector, vector_dot)
+
+
+def alternative_geodesic_dynamics(state: TangentSpace[jax.Array], metric: MetricFn) -> TangentSpace[jax.Array]:
+
+    r"""Compute geodesic dynamics, as per (Arvanitidis, G., Hansen, LK., Hauberg, S., 2018).[^1]
+
+    !!! note "Latent Space Oddity Approach"
+        The paper 'Latent Space Oddity' provides a different formulation of the geodesic equation. It is not clear why
+        this is useful or necessary, and obscures computation of the Christoffel symbols; nevertheless, an
+        implementation is provided below.
+
+        Interestingly, seminal papers: 'A Geometric take on Metric Learning', 'Metrics for Probabilistic Models' use a
+        similar approach but are missing a term. It appears that these are incorrect and should likely be revised to
+        reflect their errors.
+
+        While the mathematical specification for the alternative dynamics makes use of `vec`, I avoid this to ensure we
+        only have to compute the Jacobian of the metric tensor a single time.
+
+    [^1]:
+        Arvanitidis, Georgios, Lars Kai Hansen, and Søren Hauberg. ‘Latent Space Oddity: On the Curvature of Deep Generative Models’. arXiv, 2021. <a href="http://arxiv.org/abs/1710.11379">http://arxiv.org/abs/1710.11379</a>
+
+    Parameters:
+        state: current state of the geodesic integration
+        metric: covariant metric tensor used
+
+    Returns:
+        derivatives used to compute update for the state
+    """
+
+    contra_g_ij = contravariant_metric_tensor(state.point, metric)
+
+    dgdx = jax.jacobian(metric)(state.point)
+    central_term = 2.0 * einops.rearrange(dgdx, 'i j k -> i (j k)') - einops.rearrange(dgdx, 'i j k -> k (i j)')
+
+    vector_dot = -0.5 * contra_g_ij @ central_term @ jnp.kron(state.vector, state.vector)
+
+    return TangentSpace[jax.Array](state.vector, vector_dot)
+
+
+def _compute_discretised_energy(geodesic: TangentSpace[jax.Array], metric: MetricFn) -> jax.Array:
+    return 0.5 * inner_product(geodesic.point, geodesic.vector, geodesic.vector, metric)
+
+
+def _compute_discretised_length(geodesic: TangentSpace[jax.Array], metric: MetricFn) -> jax.Array:
+    return jnp.sqrt(inner_product(geodesic.point, geodesic.vector, geodesic.vector, metric))
+
+
+def _integrate_curve_quantity(fn_quantity: tp.Callable[[TangentSpace[jax.Array]], jax.Array], geodesic: TangentSpace[jax.Array], dt: float, integral_approximator: IntegralApproximationFn) -> jax.Array:
+    return integral_approximator(jax.vmap(fn_quantity)(geodesic), dt)
+
+
+def compute_geodesic_length(geodesic: TangentSpace[jax.Array], dt: float, metric: MetricFn, integral_approximator: IntegralApproximationFn = mean_integration) -> jax.Array:
+
+    r"""Compute length of the geodesic.
+
+    The length of a geodesic is defined as
+
+    $$
+    L(\gamma, \dot{\gamma}) = \int_0^1 \sqrt{ g_{\gamma} (\dot{\gamma}, \dot{\gamma}) } dt.
+    $$
+
+    We note that this is not necessarily equivalent to the geodesic distance between two points.
+
+    Parameters:
+        geodesic: point on the geodesic
+        metric: function to compute the metric tensor
+
+    Returns:
+        length of the geodesic
+    """
+
+    quantity_fn = jtu.Partial(_compute_discretised_length, metric=metric)
+    return _integrate_curve_quantity(quantity_fn, geodesic, dt, integral_approximator)
+
+
+def compute_geodesic_energy(geodesic: TangentSpace[jax.Array], dt: float, metric: MetricFn, integral_approximator: IntegralApproximationFn = mean_integration) -> jax.Array:
+
+    r"""Compute energy of the geodesic.
+
+    The energy of a geodesic is defined as
+
+    $$
+    E(\gamma, \dot{\gamma}) = \int_0^1 g_{\gamma} (\dot{\gamma}, \dot{\gamma}) dt.
+    $$
+
+    Parameters:
+        geodesic: point on the geodesic
+        metric: function to compute the metric tensor
+
+    Returns:
+        energy of the geodesic
+    """
+
+    quantity_fn = jtu.Partial(_compute_discretised_energy, metric=metric)
+    return _integrate_curve_quantity(quantity_fn, geodesic, dt, integral_approximator)

--- a/src/riemax/manifold/maps.py
+++ b/src/riemax/manifold/maps.py
@@ -1,0 +1,120 @@
+import functools as ft
+import typing as tp
+
+import jax
+import jax.tree_util as jtu
+
+from ..numerical.integrators import Integrator, ParametersIVP
+from ..numerical.newton_raphson import NewtonRaphsonParams, newton_raphson
+from .geodesic import geodesic_dynamics
+from .types import M, MetricFn, TangentSpace, TpM
+
+type ExponentialMap = tp.Callable[[TangentSpace[jax.Array]], tuple[M[jax.Array], TangentSpace[jax.Array]]]
+type LogMap[*Ts] = tp.Callable[[TangentSpace[jax.Array] | M[jax.Array], M[jax.Array], *Ts], tuple[TangentSpace[jax.Array], bool]]
+
+
+def _transform_integrator_to_exp[T](integrator_output: tuple[TangentSpace[T], TangentSpace[T]]):
+    final_state, full_state = integrator_output
+    return final_state.point, full_state
+
+
+def _integrator_to_exp[T](
+        fn: tp.Callable[[TangentSpace[T]], tuple[TangentSpace[T], TangentSpace[T]]]
+) -> tp.Callable[[TangentSpace[T]], tuple[M[T], TangentSpace[T]]]:
+
+    @ft.wraps(fn)
+    def _fn(state: TangentSpace[T]) -> tuple[M[T], TangentSpace[T]]:
+        return _transform_integrator_to_exp(fn(state))
+
+    return _fn
+
+
+def exponential_map_factory(integrator: Integrator[TangentSpace[jax.Array]], dt: float, metric: MetricFn, n_steps: int | None = None) -> ExponentialMap:
+
+    r"""Produce an exponential map, $\exp: TM \rightarrow M$.
+
+    !!! note "Example"
+
+        ```python
+        # ...
+
+        exp_map = exponential_map_factory(riemax.numerical.integrators.odeint, dt=1e-3, metric=fn_metric)
+        ```
+
+    Parameters:
+        integrator: choice of integrator used to propgate dynamics
+        dt: time-step for the integration
+        metric: function to compute metric tensor
+        n_steps: number of steps to integrate for
+
+    Returns:
+        exp_map: function for computing exponential map
+    """
+
+    if not n_steps:
+        n_steps = int(1.0 // dt)
+
+    dynamics = jtu.Partial(geodesic_dynamics, metric=metric)
+    ivp_params = ParametersIVP(differential_operator=dynamics, dt=dt, n_steps=n_steps)
+
+    @_integrator_to_exp
+    def exp_map(state: TangentSpace[jax.Array]) -> tuple[TangentSpace[jax.Array], TangentSpace[jax.Array]]:
+        return integrator(ivp_params, state)
+
+    return exp_map
+
+
+def shooting_log_map_factory(exp_map: ExponentialMap, nr_parameters: NewtonRaphsonParams | None = None) -> LogMap:
+
+    r"""Produce log map, computed using a shooting method.
+
+    !!! note "Efficacy of Shooting Solvers:"
+
+        Shooting solvers typically require a good initial guess. If the initial guess for the velocity vector is too far
+        from a true solution, this can tend to fail. We also note that, this does not guarantee obtaining the velocity
+        vector of the globally length-minimising geodesic -- only of a valid geodesic which connects the two points.
+
+    Parameters:
+        exp_map: function used to compute the exponential map
+        nr_parameters: parameters used in the Newton-Raphson optimisation
+
+    Returns:
+        log_map: function to compute the log map between $p, q \in M$
+    """
+
+    def log_map(
+        p: TangentSpace[jax.Array] | M[jax.Array],
+        q: M[jax.Array],
+    ) -> tuple[TangentSpace[jax.Array], bool]:
+
+        """Compute the log map between points p and q.
+
+        Parameters:
+            p: origin point on the manifold
+            q: destination point on the manifold
+            initial_p0_dot: initial guess for the tangent vector
+
+        Returns:
+            state which, when the exponential map is taken at p, yields q
+        """
+
+        if not isinstance(p, TangentSpace):
+            p = TangentSpace(point=p, vector=(q - p))
+
+        def shooting_residual(p_dot: TpM[jax.Array]) -> TpM[jax.Array]:
+
+            initial_state = TangentSpace[jax.Array](point=p.point, vector=p_dot)
+            point, _ = exp_map(initial_state)
+
+            return point - q
+
+        # root-finding for shooting residual
+        p_dot, newton_convergence_state = newton_raphson(
+            shooting_residual, initial_guess=p.vector, nr_parameters=nr_parameters
+        )
+
+        initial_condition = TangentSpace[jax.Array](point=p.point, vector=p_dot)
+
+        return initial_condition, newton_convergence_state.converged
+
+    return log_map


### PR DESCRIPTION
Provided `riemax.manifold.maps`, `riemax.manifold.geodesic`. These allow the user to
define the exponential and log maps on the manifold. The log map is currently solved
using a shooting solver -- other approaches will be added soon.

Two methods for computing the geodesic dynamics have been added. These can be used in
computing the exponential map on the manifold.
