### PR TITLE
Adopted ruff format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,10 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.0
+    rev: v0.1.2
     hooks:
       - id: ruff
+      - id: ruff-format
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.318

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,17 @@ homepage = "https://github.com/danielkelshaw/riemax"
 repository = "https://github.com/danielkelshaw/riemax"
 
 [tool.ruff]
-select = ["E", "F", "B", "I"]
-ignore = ["E501"]
-
+indent-width = 4
 line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+ignore = ["E501"]
+select = ["E", "F", "B", "I"]
+
+[tool.ruff.format]
+quote-style = "single"
+indent-style = "space"
 
 [tool.ruff.per-file-ignores]
 "**/__init__.py" = ["F401"]

--- a/src/riemax/manifold/_manifold.py
+++ b/src/riemax/manifold/_manifold.py
@@ -47,10 +47,8 @@ class Manifold:
     """
 
     def __new__(cls, metric: MetricFn, *, jit: bool = True) -> Manifold:
-
         obj = super().__new__(cls)
-        for (fn, jittable) in manifold_marker:
-
+        for fn, jittable in manifold_marker:
             p_fn = jtu.Partial(fn, metric=metric)
 
             if jittable and jit:
@@ -63,7 +61,6 @@ class Manifold:
         return obj
 
     def __init__(self, metric: MetricFn, *, jit: bool = True) -> None:
-
         """Instantiate a Manifold
 
         Parameters:
@@ -78,8 +75,9 @@ class Manifold:
         return f'Manifold(metric={self.metric_tensor.__name__})'
 
     @classmethod
-    def from_fn_transformation(cls, fn_transformation: tp.Callable[[M[jax.Array]], jax.Array], *, jit: bool = True) -> Manifold:
-
+    def from_fn_transformation(
+        cls, fn_transformation: tp.Callable[[M[jax.Array]], jax.Array], *, jit: bool = True
+    ) -> Manifold:
         """Instantiates an induced Manifold from a function transformation.
 
         Parameters:

--- a/src/riemax/manifold/_marked.py
+++ b/src/riemax/manifold/_marked.py
@@ -8,23 +8,20 @@ type ManifoldFn[*Ts, T] = tp.Callable[[*Ts, MetricFn], T]
 
 
 class _Marker[*Ts, T](tp.NamedTuple):
-
     fn: ManifoldFn[*Ts, T]
     jittable: bool
 
 
 class _ManifoldMarked:
-
     _self = None
 
     def __new__(cls) -> _ManifoldMarked:
-
         if not cls._self:
             cls._self = super().__new__(cls)
 
         return cls._self
 
-    def __init__(self)-> None:
+    def __init__(self) -> None:
         self._markers = []
 
     def __getitem__(self, idx) -> _Marker:
@@ -46,10 +43,10 @@ class _ManifoldMarked:
     def mark(self, fn: ManifoldFn) -> ManifoldFn:
         ...
 
-    def mark(self, fn: ManifoldFn | None = None, *, jittable: bool = True) -> ManifoldFn | tp.Callable[[ManifoldFn], ManifoldFn]:
-
+    def mark(
+        self, fn: ManifoldFn | None = None, *, jittable: bool = True
+    ) -> ManifoldFn | tp.Callable[[ManifoldFn], ManifoldFn]:
         def _mark(fn: ManifoldFn) -> ManifoldFn:
-
             _marker = _Marker(fn=fn, jittable=jittable)
             self._markers.append(_marker)
 

--- a/src/riemax/manifold/euclidean.py
+++ b/src/riemax/manifold/euclidean.py
@@ -3,7 +3,6 @@ import jax.numpy as jnp
 
 
 def metric_tensor(x: jax.Array) -> jax.Array:
-
     r"""Defines the metric tensor for Euclidean space.
 
     In Euclidean space, the metric tensor is defined as the identity matrix
@@ -27,7 +26,6 @@ def metric_tensor(x: jax.Array) -> jax.Array:
 
 
 def distance(p: jax.Array, q: jax.Array) -> jax.Array:
-
     r"""Compute Euclidean distance between points.
 
     The Euclidean distance is simply defined by the L2 norm:

--- a/src/riemax/manifold/geodesic.py
+++ b/src/riemax/manifold/geodesic.py
@@ -15,7 +15,6 @@ from .types import MetricFn, TangentSpace
 
 @manifold_marker.mark(jittable=True)
 def geodesic_dynamics(state: TangentSpace[jax.Array], metric: MetricFn) -> TangentSpace[jax.Array]:
-
     r"""Compute update step for the geodesic dynamics.
 
     The geodesic equation
@@ -42,7 +41,6 @@ def geodesic_dynamics(state: TangentSpace[jax.Array], metric: MetricFn) -> Tange
 
 
 def alternative_geodesic_dynamics(state: TangentSpace[jax.Array], metric: MetricFn) -> TangentSpace[jax.Array]:
-
     r"""Compute geodesic dynamics, as per (Arvanitidis, G., Hansen, LK., Hauberg, S., 2018).[^1]
 
     !!! note "Latent Space Oddity Approach"
@@ -86,12 +84,21 @@ def _compute_discretised_length(geodesic: TangentSpace[jax.Array], metric: Metri
     return jnp.sqrt(inner_product(geodesic.point, geodesic.vector, geodesic.vector, metric))
 
 
-def _integrate_curve_quantity(fn_quantity: tp.Callable[[TangentSpace[jax.Array]], jax.Array], geodesic: TangentSpace[jax.Array], dt: float, integral_approximator: IntegralApproximationFn) -> jax.Array:
+def _integrate_curve_quantity(
+    fn_quantity: tp.Callable[[TangentSpace[jax.Array]], jax.Array],
+    geodesic: TangentSpace[jax.Array],
+    dt: float,
+    integral_approximator: IntegralApproximationFn,
+) -> jax.Array:
     return integral_approximator(jax.vmap(fn_quantity)(geodesic), dt)
 
 
-def compute_geodesic_length(geodesic: TangentSpace[jax.Array], dt: float, metric: MetricFn, integral_approximator: IntegralApproximationFn = mean_integration) -> jax.Array:
-
+def compute_geodesic_length(
+    geodesic: TangentSpace[jax.Array],
+    dt: float,
+    metric: MetricFn,
+    integral_approximator: IntegralApproximationFn = mean_integration,
+) -> jax.Array:
     r"""Compute length of the geodesic.
 
     The length of a geodesic is defined as
@@ -114,8 +121,12 @@ def compute_geodesic_length(geodesic: TangentSpace[jax.Array], dt: float, metric
     return _integrate_curve_quantity(quantity_fn, geodesic, dt, integral_approximator)
 
 
-def compute_geodesic_energy(geodesic: TangentSpace[jax.Array], dt: float, metric: MetricFn, integral_approximator: IntegralApproximationFn = mean_integration) -> jax.Array:
-
+def compute_geodesic_energy(
+    geodesic: TangentSpace[jax.Array],
+    dt: float,
+    metric: MetricFn,
+    integral_approximator: IntegralApproximationFn = mean_integration,
+) -> jax.Array:
     r"""Compute energy of the geodesic.
 
     The energy of a geodesic is defined as

--- a/src/riemax/manifold/geometry.py
+++ b/src/riemax/manifold/geometry.py
@@ -9,11 +9,7 @@ from ._marked import manifold_marker
 from .types import M, MetricFn, TpM
 
 
-def pullback[**P, T](
-    f: tp.Callable[P, T],
-    fn_transformation: tp.Callable[[jax.Array], jax.Array]
-) -> tp.Callable[P, T]:
-
+def pullback[**P, T](f: tp.Callable[P, T], fn_transformation: tp.Callable[[jax.Array], jax.Array]) -> tp.Callable[P, T]:
     r"""Define the pullback of a function by a transformation.
 
     Let $\iota: M \hookrightarrow N$ be a smooth immersion, and suppose $f: N \rightarrow S$ is a smooth function on N.
@@ -52,7 +48,6 @@ def pullback[**P, T](
     """
 
     def f_pullback(*args: P.args, **kwargs: P.kwargs) -> T:
-
         args = jtu.tree_map(fn_transformation, args)
         kwargs = jtu.tree_map(fn_transformation, kwargs)
 
@@ -62,7 +57,6 @@ def pullback[**P, T](
 
 
 def metric_tensor(x: M[jax.Array], fn_transformation: tp.Callable[[M[jax.Array]], jax.Array]) -> jax.Array:
-
     r"""Computes the covariant metric tensor at a point $p \in M$
 
     Given a smooth immersion $\iota: M \hookrightarrow N$, we can define the induced metric:
@@ -93,7 +87,6 @@ def metric_tensor(x: M[jax.Array], fn_transformation: tp.Callable[[M[jax.Array]]
 
 @manifold_marker.mark(jittable=True)
 def inner_product(x: M[jax.Array], v: TpM[jax.Array], w: TpM[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Compute inner product on the tanget plane, $g_p (v, w)$.
 
     The inner product is essential for computing the magnitude of vectors on the tangent space and can be used in
@@ -114,7 +107,6 @@ def inner_product(x: M[jax.Array], v: TpM[jax.Array], w: TpM[jax.Array], metric:
 
 @manifold_marker.mark(jittable=True)
 def magnitude(x: M[jax.Array], v: TpM[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Compute length of vector on the tangent space, $\lVert v \rVert$
 
     The metric $g$ provides the ability to compute the inner product on the tangent space. Using the standard definition
@@ -138,7 +130,6 @@ def magnitude(x: M[jax.Array], v: TpM[jax.Array], metric: MetricFn) -> jax.Array
 
 @manifold_marker.mark(jittable=True)
 def contravariant_metric_tensor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Computes inverse of the metric tensor.
 
     We observe that the identity $g_{ij} g^{ij} = I$ holds. This function allows us to compute the inverse of the
@@ -166,7 +157,6 @@ def contravariant_metric_tensor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
 
 @manifold_marker.mark(jittable=True)
 def fk_christoffel(x: M[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Christoffel symbols of the first kind $\Gamma_{kij} = \left[ ij, k \right]$.
 
     These Christoffel symbols are components of the affine connection, defined as
@@ -198,7 +188,6 @@ def fk_christoffel(x: M[jax.Array], metric: MetricFn) -> jax.Array:
 
 @manifold_marker.mark(jittable=True)
 def sk_christoffel(x: M[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Christoffel symbols of the second kind: $\Gamma^k_{\phantom{k}ij} = \left\{ ij, k \right\}$
 
     The Christoffel symbols of the second-kind are simply index-raised versions of the Christoffel symbols of the first
@@ -224,7 +213,6 @@ def sk_christoffel(x: M[jax.Array], metric: MetricFn) -> jax.Array:
 
 @manifold_marker.mark(jittable=True)
 def sk_riemann_tensor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Compute Riemann curvature tensor of the second kind, $R^i_{\phantom{i}jkl}$
 
     The Riemann tensor provides a notion of curvature on the manifold. It is defined in terms of covariant derivatives
@@ -265,12 +253,10 @@ def sk_riemann_tensor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
 
 @manifold_marker.mark(jittable=True)
 def fk_riemann_tensor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Compute Riemann tensor of the first kind, $R_{ijkl}$
 
-    The Riemann tensor of the first-kind is the index-lowered variant of the
-    Riemann tensor of the second-kind. We simply apply an index contraction with
-    the metric tensor to achieve this.
+    The Riemann tensor of the first-kind is the index-lowered variant of the Riemann tensor of the second-kind. We
+    simply apply an index contraction with the metric tensor to achieve this.
 
     !!! note
         A more efficient implementation would involve computing this directly by using Christoffel symbols of the
@@ -293,7 +279,6 @@ def fk_riemann_tensor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
 
 @manifold_marker.mark(jittable=True)
 def ricci_tensor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Compute the Ricci tensor, $R_{ij}$
 
     The Ricci tensor $R_{ij}$ is a tensor contraction of the Riemann curvature tensor $R^i_{\phantom{i}jkl}$ over the
@@ -317,7 +302,6 @@ def ricci_tensor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
 
 @manifold_marker.mark(jittable=True)
 def ricci_scalar(x: M[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Compute the Ricci scalar, $R$.
 
     The Ricci scalar $R$ yields a single real number which quantifies the curvature on the manifold. It is obtained
@@ -343,7 +327,6 @@ def ricci_scalar(x: M[jax.Array], metric: MetricFn) -> jax.Array:
 
 @manifold_marker.mark(jittable=True)
 def einstein_tensor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Compute the Einstein tensor, $G_{ij}$
 
     The Einstein tensor, also known as the trace-reversed Ricci tensor is defined as
@@ -368,14 +351,13 @@ def einstein_tensor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
 
     # note: we avoid calls to `contravariant_metric_tensor, ricci_scalar`
     #       to avoid unnecessary computation of the metric and ricci tensor.
-    ricci_s = jnp.einsum('ij, ij -> ', jnp.linalg.inv(g_ij), ricci_t) # type: ignore
+    ricci_s = jnp.einsum('ij, ij -> ', jnp.linalg.inv(g_ij), ricci_t)  # type: ignore
 
     return ricci_t - 0.5 * g_ij * ricci_s
 
 
 @manifold_marker.mark(jittable=True)
 def magnification_factor(x: M[jax.Array], metric: MetricFn) -> jax.Array:
-
     r"""Compute the magnification factor.
 
     The magnification factor provides a measure of the local distortion of the distance. It is defined as

--- a/src/riemax/manifold/maps.py
+++ b/src/riemax/manifold/maps.py
@@ -10,7 +10,9 @@ from .geodesic import geodesic_dynamics
 from .types import M, MetricFn, TangentSpace, TpM
 
 type ExponentialMap = tp.Callable[[TangentSpace[jax.Array]], tuple[M[jax.Array], TangentSpace[jax.Array]]]
-type LogMap[*Ts] = tp.Callable[[TangentSpace[jax.Array] | M[jax.Array], M[jax.Array], *Ts], tuple[TangentSpace[jax.Array], bool]]
+type LogMap[*Ts] = tp.Callable[
+    [TangentSpace[jax.Array] | M[jax.Array], M[jax.Array], *Ts], tuple[TangentSpace[jax.Array], bool]
+]
 
 
 def _transform_integrator_to_exp[T](integrator_output: tuple[TangentSpace[T], TangentSpace[T]]):
@@ -19,9 +21,8 @@ def _transform_integrator_to_exp[T](integrator_output: tuple[TangentSpace[T], Ta
 
 
 def _integrator_to_exp[T](
-        fn: tp.Callable[[TangentSpace[T]], tuple[TangentSpace[T], TangentSpace[T]]]
+    fn: tp.Callable[[TangentSpace[T]], tuple[TangentSpace[T], TangentSpace[T]]]
 ) -> tp.Callable[[TangentSpace[T]], tuple[M[T], TangentSpace[T]]]:
-
     @ft.wraps(fn)
     def _fn(state: TangentSpace[T]) -> tuple[M[T], TangentSpace[T]]:
         return _transform_integrator_to_exp(fn(state))
@@ -29,8 +30,9 @@ def _integrator_to_exp[T](
     return _fn
 
 
-def exponential_map_factory(integrator: Integrator[TangentSpace[jax.Array]], dt: float, metric: MetricFn, n_steps: int | None = None) -> ExponentialMap:
-
+def exponential_map_factory(
+    integrator: Integrator[TangentSpace[jax.Array]], dt: float, metric: MetricFn, n_steps: int | None = None
+) -> ExponentialMap:
     r"""Produce an exponential map, $\exp: TM \rightarrow M$.
 
     !!! note "Example"
@@ -65,7 +67,6 @@ def exponential_map_factory(integrator: Integrator[TangentSpace[jax.Array]], dt:
 
 
 def shooting_log_map_factory(exp_map: ExponentialMap, nr_parameters: NewtonRaphsonParams | None = None) -> LogMap:
-
     r"""Produce log map, computed using a shooting method.
 
     !!! note "Efficacy of Shooting Solvers:"
@@ -86,7 +87,6 @@ def shooting_log_map_factory(exp_map: ExponentialMap, nr_parameters: NewtonRaphs
         p: TangentSpace[jax.Array] | M[jax.Array],
         q: M[jax.Array],
     ) -> tuple[TangentSpace[jax.Array], bool]:
-
         """Compute the log map between points p and q.
 
         Parameters:
@@ -102,7 +102,6 @@ def shooting_log_map_factory(exp_map: ExponentialMap, nr_parameters: NewtonRaphs
             p = TangentSpace(point=p, vector=(q - p))
 
         def shooting_residual(p_dot: TpM[jax.Array]) -> TpM[jax.Array]:
-
             initial_state = TangentSpace[jax.Array](point=p.point, vector=p_dot)
             point, _ = exp_map(initial_state)
 

--- a/src/riemax/manifold/operators.py
+++ b/src/riemax/manifold/operators.py
@@ -10,7 +10,6 @@ from .types import M, MetricFn
 
 @manifold_marker.mark(jittable=False)
 def grad(fn: tp.Callable[[M[jax.Array]], jax.Array], metric: MetricFn) -> tp.Callable[[M[jax.Array]], jax.Array]:
-
     r"""Compute gradient of scalar function on the manifold.
 
     When an inner product $\langle \cdot, \cdot \rangle$ is defined, the gradient $\nabla f$ of a function $f$ is
@@ -56,7 +55,6 @@ def grad(fn: tp.Callable[[M[jax.Array]], jax.Array], metric: MetricFn) -> tp.Cal
 
     @ft.wraps(fn)
     def transformed(x: M[jax.Array]) -> jax.Array:
-
         co_gx = metric(x)
         contra_gx = jnp.linalg.inv(co_gx)
 
@@ -69,7 +67,6 @@ def grad(fn: tp.Callable[[M[jax.Array]], jax.Array], metric: MetricFn) -> tp.Cal
 
 @manifold_marker.mark(jittable=False)
 def div(fn: tp.Callable[[M[jax.Array]], jax.Array], metric: MetricFn) -> tp.Callable[[M[jax.Array]], jax.Array]:
-
     r"""Compute divergence of vector-valued function on the manifold.
 
     Given a vector field $X \in TM$, we define the divergence as[^1][^2]
@@ -91,12 +88,10 @@ def div(fn: tp.Callable[[M[jax.Array]], jax.Array], metric: MetricFn) -> tp.Call
 
     @ft.wraps(fn)
     def transformed(x: M[jax.Array]) -> jax.Array:
-
         co_gx = metric(x)
         sqrt_det_co_gx = jnp.sqrt(jnp.linalg.det(co_gx))
 
         def _inner(_x: M[jax.Array]) -> jax.Array:
-
             co_gx_inner = metric(_x)
             sqrt_det_co_gx_inner = jnp.sqrt(jnp.linalg.det(co_gx_inner))
 
@@ -115,8 +110,9 @@ def div(fn: tp.Callable[[M[jax.Array]], jax.Array], metric: MetricFn) -> tp.Call
 
 
 @manifold_marker.mark(jittable=False)
-def laplace_beltrami(fn: tp.Callable[[M[jax.Array]], jax.Array], metric: MetricFn) -> tp.Callable[[M[jax.Array]], jax.Array]:
-
+def laplace_beltrami(
+    fn: tp.Callable[[M[jax.Array]], jax.Array], metric: MetricFn
+) -> tp.Callable[[M[jax.Array]], jax.Array]:
     r"""Compute laplacian of scalar-valued function on the manifold.
 
     Given a function $f: M \rightarrow \mathbb{R}$, we can compute the Laplacian by taking the divergence of the

--- a/src/riemax/numerical/integral_approximators.py
+++ b/src/riemax/numerical/integral_approximators.py
@@ -7,7 +7,6 @@ type IntegralApproximationFn = tp.Callable[[jax.Array, float], jax.Array]
 
 
 def mean_integration(fx: jax.Array, _: float) -> jax.Array:
-
     """Integration by taking mean.
 
     Parameters:
@@ -25,7 +24,6 @@ def mean_integration(fx: jax.Array, _: float) -> jax.Array:
 
 
 def trapezoidal_integration(fx: jax.Array, h: float) -> jax.Array:
-
     """Integration by trapezoidal rule.
 
     Parameters:
@@ -43,7 +41,6 @@ def trapezoidal_integration(fx: jax.Array, h: float) -> jax.Array:
 
 
 def simpsons_integration(fx: jax.Array, h: float) -> jax.Array:
-
     """Integration by Simpsons 1/3 rule.
 
     Parameters:


### PR DESCRIPTION
Started using `ruff format`, an alternative to `black` for formatting
code within the project. This has also been added as a pre-commit hook
for ease of development.
